### PR TITLE
Fix account name

### DIFF
--- a/anchor-contributor/tests/helpers/contributor.ts
+++ b/anchor-contributor/tests/helpers/contributor.ts
@@ -42,7 +42,7 @@ export class IccoContributor {
     return program.methods
       .createCustodian()
       .accounts({
-        owner: payer.publicKey,
+        payer: payer.publicKey,
         custodian: this.custodian,
         systemProgram: web3.SystemProgram.programId,
       })


### PR DESCRIPTION
Account name was wrong in createCustodian. Tests seem to run fine either way, but wanted to make the accounts listed consistent with the program context.