### PR TITLE
add pause functionality in conductor and contributor for owner to stop operations.

### DIFF
--- a/anchor-contributor/programs/anchor-contributor/src/constants.rs
+++ b/anchor-contributor/programs/anchor-contributor/src/constants.rs
@@ -10,6 +10,7 @@ pub const PAYLOAD_SALE_INIT_SOLANA: u8 = 5; // 1 for everyone else
 pub const PAYLOAD_ATTEST_CONTRIBUTIONS: u8 = 2;
 pub const PAYLOAD_SALE_SEALED: u8 = 3;
 pub const PAYLOAD_SALE_ABORTED: u8 = 4;
+pub const PAYLOAD_KYC_AUTHORITY_UPDATED: u8 = 6;
 
 // universal
 pub const PAYLOAD_HEADER_LEN: usize = 33; // payload + sale id
@@ -22,7 +23,7 @@ pub const INDEX_SALE_INIT_TOKEN_DECIMALS: usize = 67;
 pub const INDEX_SALE_INIT_SALE_START: usize = 68;
 pub const INDEX_SALE_INIT_SALE_END: usize = 100;
 pub const INDEX_SALE_INIT_ACCEPTED_TOKENS_START: usize = 132;
-pub const SALE_INIT_TAIL:  usize = 84;
+pub const SALE_INIT_TAIL: usize = 84;
 
 pub const ACCEPTED_TOKEN_NUM_BYTES: usize = 33;
 pub const ACCEPTED_TOKENS_MAX: usize = 8;

--- a/anchor-contributor/programs/anchor-contributor/src/error.rs
+++ b/anchor-contributor/programs/anchor-contributor/src/error.rs
@@ -109,4 +109,19 @@ pub enum ContributorError {
 
     #[msg("InvalidAcceptedTokenATA")]
     InvalidAcceptedTokenATA,
+
+    #[msg("InvalidWormholeMessageAccount")]
+    InvalidWormholeMessageAccount,
+
+    #[msg("InvalidTokenBridgeProgram")]
+    InvalidTokenBridgeProgram,
+
+    #[msg("InvalidWormholeProgram")]
+    InvalidWormholeProgram,
+
+    #[msg("InvalidSystemProgram")]
+    InvalidSystemProgram,
+
+    #[msg("InvalidSaleTokenATA")]
+    InvalidSaleTokenATA,
 }

--- a/anchor-contributor/tests/anchor-contributor.ts
+++ b/anchor-contributor/tests/anchor-contributor.ts
@@ -32,7 +32,10 @@ import {
   CONDUCTOR_ADDRESS,
   CONDUCTOR_CHAIN,
   CORE_BRIDGE_ADDRESS,
-  KYC_PRIVATE,
+  KYC_PRIVATE_NEW,
+  KYC_PRIVATE_OLD,
+  KYC_PUBLIC_NEW,
+  KYC_PUBLIC_OLD,
   TOKEN_BRIDGE_ADDRESS,
 } from "./helpers/consts";
 import { encodeAttestMeta, encodeTokenTransfer, parseTokenTransfer } from "./helpers/token-bridge";
@@ -64,7 +67,7 @@ describe("anchor-contributor", () => {
   const contributor = new IccoContributor(program, CORE_BRIDGE_ADDRESS, TOKEN_BRIDGE_ADDRESS, postVaaSolanaWithRetry);
 
   // kyc for signing contributions
-  const kyc = new KycAuthority(KYC_PRIVATE, CONDUCTOR_ADDRESS, contributor);
+  const kyc = new KycAuthority(KYC_PRIVATE_OLD, CONDUCTOR_ADDRESS, contributor);
 
   // Mock Token Bridge on Ethereum. Used when we attest tokens on Solana.
   const ethTokenBridge = Buffer.from(
@@ -249,7 +252,8 @@ describe("anchor-contributor", () => {
         lockPeriod,
         dummyConductor.saleTokenOnSolana,
         CHAIN_ID_SOLANA,
-        saleTokenDecimals
+        saleTokenDecimals,
+        KYC_PUBLIC_OLD
       );
       const tx = await contributor.initSale(orchestrator, initSaleVaa);
 
@@ -267,7 +271,7 @@ describe("anchor-contributor", () => {
         expect(saleState.times.end.toString()).to.equal(dummyConductor.saleEnd.toString());
         expect(saleState.times.unlockAllocation.toString()).to.equal(dummyConductor.saleUnlock.toString());
         expect(Uint8Array.from(saleState.recipient)).to.deep.equal(Buffer.from(dummyConductor.recipient, "hex"));
-        expect(Uint8Array.from(saleState.kycAuthority)).to.deep.equal(Buffer.from(dummyConductor.kycAuthority, "hex"));
+        expect(Uint8Array.from(saleState.kycAuthority)).to.deep.equal(Buffer.from(KYC_PUBLIC_OLD, "hex"));
         expect(saleState.status).has.key("active");
         expect(saleState.contributionsBlocked).to.equal(false);
 
@@ -384,7 +388,9 @@ describe("anchor-contributor", () => {
         );
         throw new Error(`should not happen: ${tx}`);
       } catch (e) {
-        caughtError = verifyErrorMsg(e, "The program expected this account to be already initialized");
+        caughtError =
+          verifyErrorMsg(e, "The program expected this account to be already initialized", false) ||
+          verifyErrorMsg(e, "The given account is owned by a different program than expected");
       }
 
       if (!caughtError) {
@@ -396,8 +402,8 @@ describe("anchor-contributor", () => {
       // prep contributions info
       const acceptedTokens = dummyConductor.acceptedTokens;
       const contributedTokenIndices = [acceptedTokens[0].index, acceptedTokens[3].index];
-      contributions.set(contributedTokenIndices[0], ["1200000000", "3400000000"]);
-      contributions.set(contributedTokenIndices[1], ["5600000000", "7800000000"]);
+      contributions.set(contributedTokenIndices[0], ["200000000", "400000000"]);
+      contributions.set(contributedTokenIndices[1], ["600000000", "800000000"]);
 
       contributedTokenIndices.forEach((tokenIndex) => {
         const amounts = contributions.get(tokenIndex);
@@ -470,7 +476,167 @@ describe("anchor-contributor", () => {
           );
 
           let item = totals[i];
-          const expectedState = contribution.eq(new BN("0")) ? "inactive" : "active";
+          const expectedState = contribution.eq(new BN(0)) ? "inactive" : "active";
+          expect(item.status).has.key(expectedState);
+          expect(item.amount.toString()).to.equal(contribution.toString());
+          expect(item.excess.toString()).to.equal("0");
+        }
+      }
+
+      // check sale state
+      {
+        const saleState = await contributor.getSale(saleId);
+        const totals = saleState.totals as any[];
+        expect(totals.length).to.equal(numExpected);
+
+        for (let i = 0; i < numExpected; ++i) {
+          const total = totals[i];
+          expect(total.contributions.toString()).to.equal(expectedContributedAmounts[i].toString());
+          expect(total.allocations.toString()).to.equal("0");
+          expect(total.excessContributions.toString()).to.equal("0");
+        }
+      }
+    });
+
+    it("Orchestrator Updates Sale's KYC Authority with Signed VAA", async () => {
+      const kycAuthorityUpdatedVaa = dummyConductor.updateKycAuthority(await getBlockTime(connection), KYC_PUBLIC_NEW);
+      const tx = await contributor.updateKycAuthority(orchestrator, kycAuthorityUpdatedVaa);
+
+      {
+        const saleId = dummyConductor.getSaleId();
+        const saleState = await contributor.getSale(saleId);
+        expect(Uint8Array.from(saleState.kycAuthority)).to.deep.equal(Buffer.from(KYC_PUBLIC_NEW, "hex"));
+      }
+    });
+
+    it("User Cannot Contribute with Old KYC Authority", async () => {
+      const saleId = dummyConductor.getSaleId();
+      const tokenIndex = 2;
+      const amount = new BN("1000000000"); // 1,000,000,000 lamports
+
+      let caughtError = false;
+      try {
+        const tx = await contributor.contribute(
+          buyer,
+          saleId,
+          tokenIndex,
+          amount,
+          await kyc.signContribution(saleId, tokenIndex, amount, buyer.publicKey)
+        );
+        throw new Error(`should not happen: ${tx}`);
+      } catch (e) {
+        caughtError = verifyErrorMsg(e, "InvalidKycSignature");
+      }
+
+      if (!caughtError) {
+        throw new Error("did not catch expected error");
+      }
+    });
+
+    it("User Contributes More with New KYC Signatures", async () => {
+      // update KYC authority
+      kyc.updatePrivateKey(KYC_PRIVATE_NEW);
+
+      // prep contributions info
+      const acceptedTokens = dummyConductor.acceptedTokens;
+      const contributedTokenIndices = [acceptedTokens[0].index, acceptedTokens[3].index];
+      const moreContributions = new Map<number, string[]>();
+      moreContributions.set(contributedTokenIndices[0], ["1000000000", "3000000000"]);
+      moreContributions.set(contributedTokenIndices[1], ["5000000000", "7000000000"]);
+
+      const thisRoundTotalContributions: BN[] = [];
+      totalContributions.splice(0);
+
+      contributedTokenIndices.forEach((tokenIndex) => {
+        const moreAmounts = moreContributions.get(tokenIndex);
+        thisRoundTotalContributions.push(moreAmounts.map((x) => new BN(x)).reduce((prev, curr) => prev.add(curr)));
+
+        const amounts = contributions.get(tokenIndex);
+        amounts.push(...moreContributions.get(tokenIndex));
+        totalContributions.push(amounts.map((x) => new BN(x)).reduce((prev, curr) => prev.add(curr)));
+      });
+
+      const acceptedMints = acceptedTokens.map((token) => hexToPublicKey(token.address));
+
+      const startingBalanceBuyer = await Promise.all(
+        acceptedMints.map(async (mint) => {
+          return getSplBalance(connection, mint, buyer.publicKey);
+        })
+      );
+      const startingBalanceCustodian = await Promise.all(
+        acceptedMints.map(async (mint) => {
+          return getPdaSplBalance(connection, mint, contributor.custodian);
+        })
+      );
+
+      // now go about your business
+      // contribute multiple times
+      const saleId = dummyConductor.getSaleId();
+      for (const tokenIndex of contributedTokenIndices) {
+        for (const amount of moreContributions.get(tokenIndex).map((value) => new BN(value))) {
+          const tx = await contributor.contribute(
+            buyer,
+            saleId,
+            tokenIndex,
+            amount,
+            await kyc.signContribution(saleId, tokenIndex, amount, buyer.publicKey)
+          );
+        }
+      }
+
+      const endingBalanceBuyer = await Promise.all(
+        acceptedMints.map(async (mint) => {
+          return getSplBalance(connection, mint, buyer.publicKey);
+        })
+      );
+      const endingBalanceCustodian = await Promise.all(
+        acceptedMints.map(async (mint) => {
+          return getPdaSplBalance(connection, mint, contributor.custodian);
+        })
+      );
+
+      const expectedThisRoundContributedAmounts = [
+        thisRoundTotalContributions[0],
+        new BN(0),
+        new BN(0),
+        thisRoundTotalContributions[1],
+        new BN(0),
+        new BN(0),
+        new BN(0),
+        new BN(0),
+      ];
+
+      const expectedContributedAmounts = [
+        totalContributions[0],
+        new BN(0),
+        new BN(0),
+        totalContributions[1],
+        new BN(0),
+        new BN(0),
+        new BN(0),
+        new BN(0),
+      ];
+      const numExpected = expectedContributedAmounts.length;
+
+      // check buyer state
+      {
+        const buyerState = await contributor.getBuyer(saleId, buyer.publicKey);
+        const totals = buyerState.contributions as any[];
+        expect(totals.length).to.equal(numExpected);
+
+        // check balance changes and state
+        for (let i = 0; i < numExpected; ++i) {
+          let thisRoundContribution = expectedThisRoundContributedAmounts[i];
+          expect(startingBalanceBuyer[i].sub(thisRoundContribution).toString()).to.equal(
+            endingBalanceBuyer[i].toString()
+          );
+          expect(startingBalanceCustodian[i].add(thisRoundContribution).toString()).to.equal(
+            endingBalanceCustodian[i].toString()
+          );
+
+          let item = totals[i];
+          let contribution = expectedContributedAmounts[i];
+          const expectedState = contribution.eq(new BN(0)) ? "inactive" : "active";
           expect(item.status).has.key(expectedState);
           expect(item.amount.toString()).to.equal(contribution.toString());
           expect(item.excess.toString()).to.equal("0");
@@ -924,7 +1090,8 @@ describe("anchor-contributor", () => {
         lockPeriod,
         dummyConductor.tokenAddress,
         dummyConductor.tokenChain,
-        dummyConductor.tokenDecimals
+        dummyConductor.tokenDecimals,
+        KYC_PUBLIC_NEW
       );
       const tx = await contributor.initSale(orchestrator, initSaleVaa);
 
@@ -942,7 +1109,7 @@ describe("anchor-contributor", () => {
         expect(saleState.times.end.toString()).to.equal(dummyConductor.saleEnd.toString());
         expect(saleState.times.unlockAllocation.toString()).to.equal(dummyConductor.saleUnlock.toString());
         expect(Uint8Array.from(saleState.recipient)).to.deep.equal(Buffer.from(dummyConductor.recipient, "hex"));
-        expect(Uint8Array.from(saleState.kycAuthority)).to.deep.equal(Buffer.from(dummyConductor.kycAuthority, "hex"));
+        expect(Uint8Array.from(saleState.kycAuthority)).to.deep.equal(Buffer.from(KYC_PUBLIC_NEW, "hex"));
         expect(saleState.status).has.key("active");
         expect(saleState.contributionsBlocked).to.equal(false);
 
@@ -1116,7 +1283,8 @@ describe("anchor-contributor", () => {
         lockPeriod,
         orchestrator.publicKey.toString(), // obviously not an SPL token
         CHAIN_ID_SOLANA,
-        7
+        7,
+        KYC_PUBLIC_NEW
       );
       const tx = await contributor.initSale(orchestrator, initSaleVaa);
 
@@ -1136,7 +1304,7 @@ describe("anchor-contributor", () => {
         expect(saleState.times.end.toString()).to.equal(dummyConductor.saleEnd.toString());
         expect(saleState.times.unlockAllocation.toString()).to.equal(dummyConductor.saleUnlock.toString());
         expect(Uint8Array.from(saleState.recipient)).to.deep.equal(Buffer.from(dummyConductor.recipient, "hex"));
-        expect(Uint8Array.from(saleState.kycAuthority)).to.deep.equal(Buffer.from(dummyConductor.kycAuthority, "hex"));
+        expect(Uint8Array.from(saleState.kycAuthority)).to.deep.equal(Buffer.from(KYC_PUBLIC_NEW, "hex"));
         expect(saleState.status).has.key("active");
         expect(saleState.contributionsBlocked).to.equal(true);
 
@@ -1268,7 +1436,8 @@ describe("anchor-contributor", () => {
         lockPeriod,
         "0x" + foreignSaleTokenAddress.subarray(12, 32).toString("hex"),
         CHAIN_ID_ETH,
-        18
+        18,
+        KYC_PUBLIC_NEW
       );
 
       let caughtError = false;
@@ -1349,7 +1518,7 @@ describe("anchor-contributor", () => {
         expect(saleState.times.end.toString()).to.equal(dummyConductor.saleEnd.toString());
         expect(saleState.times.unlockAllocation.toString()).to.equal(dummyConductor.saleUnlock.toString());
         expect(Uint8Array.from(saleState.recipient)).to.deep.equal(Buffer.from(dummyConductor.recipient, "hex"));
-        expect(Uint8Array.from(saleState.kycAuthority)).to.deep.equal(Buffer.from(dummyConductor.kycAuthority, "hex"));
+        expect(Uint8Array.from(saleState.kycAuthority)).to.deep.equal(Buffer.from(KYC_PUBLIC_NEW, "hex"));
         expect(saleState.status).has.key("active");
         expect(saleState.contributionsBlocked).to.equal(false);
 
@@ -1456,7 +1625,7 @@ describe("anchor-contributor", () => {
           );
 
           let item = totals[i];
-          const expectedState = contribution.eq(new BN("0")) ? "inactive" : "active";
+          const expectedState = contribution.eq(new BN(0)) ? "inactive" : "active";
           expect(item.status).has.key(expectedState);
           expect(item.amount.toString()).to.equal(contribution.toString());
           expect(item.excess.toString()).to.equal("0");
@@ -1603,7 +1772,7 @@ describe("anchor-contributor", () => {
         )
           .then((transaction) => {
             transaction.partialSign(orchestrator);
-            return connection.sendRawTransaction(transaction.serialize(), { skipPreflight: true });
+            return connection.sendRawTransaction(transaction.serialize());
           })
           .then((tx) => connection.confirmTransaction(tx));
       }

--- a/anchor-contributor/tests/helpers/conductor.ts
+++ b/anchor-contributor/tests/helpers/conductor.ts
@@ -26,6 +26,7 @@ export class DummyConductor {
   tokenChain: number;
   tokenDecimals: number;
   nativeTokenDecimals: number;
+  kycAuthority: string;
 
   initSaleVaa: Buffer;
 
@@ -83,12 +84,9 @@ export class DummyConductor {
     lockPeriod: number,
     tokenAddress: string,
     tokenChain: number,
-    tokenDecimals: number
+    tokenDecimals: number,
+    kycAuthority: string
   ): Buffer {
-    // uptick saleId for every new sale
-    ++this.saleId;
-    ++this.wormholeSequence;
-
     // set up sale time based on block time
     this.saleStart = startTime;
     this.saleEnd = this.saleStart + duration;
@@ -100,14 +98,16 @@ export class DummyConductor {
 
     this.nativeTokenDecimals = this.tokenChain == 1 ? this.tokenDecimals : 8;
 
+    this.kycAuthority = kycAuthority;
+
     this.initSaleVaa = signAndEncodeVaa(
       startTime,
       this.nonce,
       this.chainId,
       this.address,
-      this.wormholeSequence,
+      ++this.wormholeSequence,
       encodeSaleInit(
-        this.saleId,
+        ++this.saleId,
         tryNativeToHexString(this.tokenAddress, this.tokenChain as ChainId),
         this.tokenChain,
         this.tokenDecimals,
@@ -128,7 +128,6 @@ export class DummyConductor {
   }
 
   sealSale(blockTime: number, contributions: Map<number, string[]>): Buffer {
-    ++this.wormholeSequence;
     this.allocations = [];
 
     const allocationMultiplier = new BN(this.getAllocationMultiplier());
@@ -157,27 +156,36 @@ export class DummyConductor {
       this.nonce,
       this.chainId,
       this.address,
-      this.wormholeSequence,
+      ++this.wormholeSequence,
       encodeSaleSealed(this.saleId, this.allocations)
     );
   }
 
   abortSale(blockTime: number): Buffer {
-    ++this.wormholeSequence;
     return signAndEncodeVaa(
       blockTime,
       this.nonce,
       this.chainId,
       this.address,
-      this.wormholeSequence,
+      ++this.wormholeSequence,
       encodeSaleAborted(this.saleId)
     );
   }
 
+  updateKycAuthority(blockTime: number, kycAuthority: string): Buffer {
+    this.kycAuthority = kycAuthority;
+    return signAndEncodeVaa(
+      blockTime,
+      this.nonce,
+      this.chainId,
+      this.address,
+      ++this.wormholeSequence,
+      encodeKycAuthorityUpdated(this.saleId, kycAuthority)
+    );
+  }
+
   // sale parameters that won't change for the test
-  //associatedTokenAddress = "00000000000000000000000083752ecafebf4707258dedffbd9c7443148169db";
   recipient = tryNativeToHexString("0x22d491bde2303f2f43325b2108d26f1eaba1e32b", CHAIN_ID_ETH);
-  kycAuthority = "1df62f291b2e969fb0849d99d9ce41e2f137006e";
 
   // we won't use all of these, but these are purely to verify decimal shift
   expectedAllocations = [
@@ -286,5 +294,16 @@ export function encodeSaleAborted(saleId: number): Buffer {
   const encoded = Buffer.alloc(33);
   encoded.writeUInt8(4, 0); // saleSealed payload = 4
   encoded.write(toBigNumberHex(saleId, 32), 1, "hex");
+  return encoded;
+}
+
+export function encodeKycAuthorityUpdated(
+  saleId: number,
+  kycAuthority: string // 20 bytes (ethereum address)
+): Buffer {
+  const encoded = Buffer.alloc(53);
+  encoded.writeUInt8(6, 0); // AuthorityUpdated payload = 6
+  encoded.write(toBigNumberHex(saleId, 32), 1, "hex");
+  encoded.write(kycAuthority, 33, "hex");
   return encoded;
 }

--- a/anchor-contributor/tests/helpers/consts.ts
+++ b/anchor-contributor/tests/helpers/consts.ts
@@ -1,8 +1,6 @@
-import { hexToUint8Array } from "@certusone/wormhole-sdk";
 import { web3 } from "@project-serum/anchor";
 
 // wormhole
-//export const CORE_BRIDGE_ADDRESS = new web3.PublicKey("Bridge1p5gheXUvJ6jGWGeCsgPKgnE3YgdGKRVCMY9o");
 export const CORE_BRIDGE_ADDRESS = new web3.PublicKey(process.env.CORE_BRIDGE_ADDRESS);
 export const TOKEN_BRIDGE_ADDRESS = new web3.PublicKey(process.env.TOKEN_BRIDGE_ADDRESS);
 
@@ -11,4 +9,8 @@ export const CONDUCTOR_CHAIN: number = parseInt(process.env.CONDUCTOR_CHAIN);
 export const CONDUCTOR_ADDRESS: string = process.env.CONDUCTOR_ADDRESS;
 
 // kyc
-export const KYC_PRIVATE: string = "b0057716d5917badaf911b193b12b910811c1497b5bada8d7711f758981c3773";
+export const KYC_PRIVATE_OLD: string = "b0057716d5917badaf911b193b12b910811c1497b5bada8d7711f758981c3773";
+export const KYC_PUBLIC_OLD: string = "1df62f291b2e969fb0849d99d9ce41e2f137006e";
+
+export const KYC_PRIVATE_NEW: string = "cfb12303a19cde580bb4dd771639b0d26bc68353645571a8cff516ab2ee113a0";
+export const KYC_PUBLIC_NEW: string = "befa429d57cd18b7f8a4d91a2da9ab4af05d0fbe";

--- a/anchor-contributor/tests/helpers/kyc.ts
+++ b/anchor-contributor/tests/helpers/kyc.ts
@@ -12,7 +12,7 @@ export class KycAuthority {
   contributor: IccoContributor;
 
   constructor(privateKey: string, conductorAddress: string, contributor: IccoContributor) {
-    this.privateKey = Buffer.from(privateKey, "hex");
+    this.updatePrivateKey(privateKey);
     this.conductorAddress = conductorAddress;
     this.contributor = contributor;
   }
@@ -65,5 +65,9 @@ export class KycAuthority {
     packed.write(signature.s.toString(16).padStart(64, "0"), 32, "hex");
     packed.writeUInt8(signature.recoveryParam, 64);
     return packed;
+  }
+
+  updatePrivateKey(privateKey: string) {
+    this.privateKey = Buffer.from(privateKey, "hex");
   }
 }

--- a/ethereum/CONDUCTOR_ERROR_CODES.md
+++ b/ethereum/CONDUCTOR_ERROR_CODES.md
@@ -1,50 +1,51 @@
 | Code | Contract            | Function                        | Reason                                             |
 | ---- | ------------------- | ------------------------------- | -------------------------------------------------- |
 | 1    | Conductor           | receiveSaleToken                | wrapped address not found on this chain            |
-| 2    | Conductor           | receiveSaleToken                | fee-on-transfer tokens are not supported           |
-| 3    | Conductor           | createSale                      | sale start must be in the future                   |
-| 4    | Conductor           | createSale                      | sale end must be after sale start                  |
-| 5    | Conductor           | createSale                      | unlock timestamp should be >= saleEnd              |
-| 6    | Conductor           | createSale                      | unlock timestamp must be <= 2 years in the future  |
-| 7    | Conductor           | createSale                      | timestamp too large                                |
-| 8    | Conductor           | createSale                      | sale token amount must be > 0 and <= 2^63-1        |
-| 9    | Conductor           | createSale                      | must accept at least one token                     |
-| 10   | Conductor           | createSale                      | too many tokens                                    |
-| 11   | Conductor           | createSale                      | minRaise must be > 0                               |
-| 12   | Conductor           | createSale                      | maxRaise must be >= minRaise                       |
-| 13   | Conductor           | createSale                      | token must not be bytes32(0)                       |
-| 14   | Conductor           | createSale                      | recipient must not be address(0)                   |
-| 15   | Conductor           | createSale                      | refundRecipient must not be address(0)             |
-| 16   | Conductor           | createSale                      | authority must not be address(0) or the owner      |
-| 17   | Conductor           | createSale                      | insufficient value                                 |
-| 18   | Conductor           | createSale                      | duplicate tokens not allowed                       |
-| 19   | Conductor           | createSale                      | conversion rate cannot be zero                     |
-| 20   | Conductor           | createSale                      | acceptedTokens.tokenAddress must not be bytes32(0) |
-| 21   | Conductor           | createSale                      | too many solana tokens                             |
-| 22   | Conductor           | abortSaleBeforeStartTime        | sale not initiated                                 |
-| 23   | Conductor           | abortSaleBeforeStartTime        | only initiator can abort the sale early            |
-| 24   | Conductor           | abortSaleBeforeStartTime        | already sealed / aborted                           |
-| 25   | Conductor           | abortSaleBeforeStartTime        | sale cannot be aborted once it has started         |
-| 26   | Conductor           | abortSaleBeforeStartTime        | insufficient value                                 |
-| 27   | Conductor           | collectContribution             | invalid emitter                                    |
-| 28   | Conductor           | collectContribution             | contribution from wrong chain id                   |
-| 29   | Conductor           | collectContribution             | sale was aborted                                   |
-| 30   | Conductor           | collectContribution             | sale has not ended yet                             |
-| 31   | Conductor           | collectContribution             | no contributions                                   |
-| 32   | Conductor           | collectContribution             | contribution already collected                     |
-| 33   | Conductor           | sealSale                        | sale not initiated                                 |
-| 34   | Conductor           | sealSale                        | already sealed / aborted                           |
-| 35   | Conductor           | sealSale                        | missing contribution info                          |
-| 36   | Conductor           | sealSale                        | insufficient value                                 |
-| 37   | Conductor           | updateSaleAuthority             | sale not initiated                                 |
-| 38   | Conductor           | updateSaleAuthority             | new authority must not be address(0) or the owner  |
-| 39   | Conductor           | updateSaleAuthority             | unauthorized authority key                         |
-| 40   | Conductor           | updateSaleAuthority             | already sealed / aborted                           |
-| 41   | Conductor           | updateSaleAuthority             | incorrect value for messageFee                     |
-| 42   | Conductor           | abortBrickedSale                | sale not initiated                                 |
-| 43   | Conductor           | abortBrickedSale                | already sealed / aborted"                          |
-| 44   | Conductor           | abortBrickedSale                | sale not old enough                                |
-| 45   | Conductor           | abortBrickedSale                | incorrect value                                    |
+| 2    | Conductor           | receiveSaleToken                | sale token amount too large                        |
+| 3    | Conductor           | receiveSaleToken                | fee-on-transfer tokens are not supported           |
+| 4    | Conductor           | createSale                      | sale start must be in the future                   |
+| 5    | Conductor           | createSale                      | sale end must be after sale start                  |
+| 6    | Conductor           | createSale                      | unlock timestamp should be >= saleEnd              |
+| 7    | Conductor           | createSale                      | unlock timestamp must be <= 2 years in the future  |
+| 8    | Conductor           | createSale                      | timestamp too large                                |
+| 9    | Conductor           | createSale                      | sale token amount must be > 0                      |
+| 10   | Conductor           | createSale                      | must accept at least one token                     |
+| 11   | Conductor           | createSale                      | too many tokens                                    |
+| 12   | Conductor           | createSale                      | minRaise must be > 0                               |
+| 13   | Conductor           | createSale                      | maxRaise must be >= minRaise                       |
+| 14   | Conductor           | createSale                      | token must not be bytes32(0)                       |
+| 15   | Conductor           | createSale                      | recipient must not be address(0)                   |
+| 16   | Conductor           | createSale                      | refundRecipient must not be address(0)             |
+| 17   | Conductor           | createSale                      | authority must not be address(0) or the owner      |
+| 18   | Conductor           | createSale                      | insufficient value                                 |
+| 19   | Conductor           | createSale                      | duplicate tokens not allowed                       |
+| 20   | Conductor           | createSale                      | conversion rate cannot be zero                     |
+| 21   | Conductor           | createSale                      | acceptedTokens.tokenAddress must not be bytes32(0) |
+| 22   | Conductor           | createSale                      | too many solana tokens                             |
+| 23   | Conductor           | abortSaleBeforeStartTime        | sale not initiated                                 |
+| 24   | Conductor           | abortSaleBeforeStartTime        | only initiator can abort the sale early            |
+| 25   | Conductor           | abortSaleBeforeStartTime        | already sealed / aborted                           |
+| 26   | Conductor           | abortSaleBeforeStartTime        | sale cannot be aborted once it has started         |
+| 27   | Conductor           | abortSaleBeforeStartTime        | insufficient value                                 |
+| 28   | Conductor           | collectContribution             | invalid emitter                                    |
+| 29   | Conductor           | collectContribution             | contribution from wrong chain id                   |
+| 30   | Conductor           | collectContribution             | sale was aborted                                   |
+| 31   | Conductor           | collectContribution             | sale has not ended yet                             |
+| 32   | Conductor           | collectContribution             | no contributions                                   |
+| 33   | Conductor           | collectContribution             | contribution already collected                     |
+| 34   | Conductor           | sealSale                        | sale not initiated                                 |
+| 35   | Conductor           | sealSale                        | already sealed / aborted                           |
+| 36   | Conductor           | sealSale                        | missing contribution info                          |
+| 37   | Conductor           | sealSale                        | insufficient value                                 |
+| 38   | Conductor           | updateSaleAuthority             | sale not initiated                                 |
+| 39   | Conductor           | updateSaleAuthority             | new authority must not be address(0) or the owner  |
+| 40   | Conductor           | updateSaleAuthority             | unauthorized authority key                         |
+| 41   | Conductor           | updateSaleAuthority             | already sealed / aborted                           |
+| 42   | Conductor           | updateSaleAuthority             | incorrect value for messageFee                     |
+| 43   | Conductor           | abortBrickedSale                | sale not initiated                                 |
+| 44   | Conductor           | abortBrickedSale                | already sealed / aborted"                          |
+| 45   | Conductor           | abortBrickedSale                | sale not old enough                                |
+| 46   | Conductor           | abortBrickedSale                | incorrect value                                    |
 | 1    | ConductorSetup      | setup                           | wormhole address must not be address(0)            |
 | 2    | ConductorSetup      | setup                           | tokenBridge's address must not be address(0)       |
 | 3    | ConductorSetup      | setup                           | implementation's address must not be address(0)    |

--- a/ethereum/contracts/icco/conductor/Conductor.sol
+++ b/ethereum/contracts/icco/conductor/Conductor.sol
@@ -55,6 +55,16 @@ contract Conductor is ConductorGovernance, ConductorEvents, ReentrancyGuard {
         );
         uint8 localTokenDecimals = abi.decode(queriedDecimals, (uint8));
 
+        /**
+         * @dev Set a maximum sale.tokenAmount so that the Solana contributor
+         * is able to redeem all token bridge transfers from this contract.
+         */
+        if (localTokenDecimals > 8) {
+            require(raise.tokenAmount < (2 ** 64 - 1) * 10 ** (localTokenDecimals - 8), "2");
+        } else {
+            require(raise.tokenAmount < 2 ** 64 - 1, "2");
+        }
+
         /// query own token balance before transfer
         (,bytes memory queriedBalanceBefore) = localTokenAddress.staticcall(
             abi.encodeWithSelector(IERC20.balanceOf.selector, 
@@ -78,7 +88,7 @@ contract Conductor is ConductorGovernance, ConductorEvents, ReentrancyGuard {
         uint256 balanceAfter = abi.decode(queriedBalanceAfter, (uint256));
 
         /// revert if token has fee
-        require(raise.tokenAmount == balanceAfter - balanceBefore, "2");
+        require(raise.tokenAmount == balanceAfter - balanceBefore, "3");
 
         return (localTokenAddress, localTokenDecimals);
     }
@@ -99,23 +109,23 @@ contract Conductor is ConductorGovernance, ConductorEvents, ReentrancyGuard {
         uint256 wormholeSequence2
     ) {
         /// validate sale parameters from client
-        require(block.timestamp < raise.saleStart, "3");
-        require(raise.saleStart < raise.saleEnd, "4");
-        require(raise.unlockTimestamp >= raise.saleEnd, "5");
-        require(raise.unlockTimestamp - raise.saleEnd <= 63072000, "6");
+        require(block.timestamp < raise.saleStart, "4");
+        require(raise.saleStart < raise.saleEnd, "5");
+        require(raise.unlockTimestamp >= raise.saleEnd, "6");
+        require(raise.unlockTimestamp - raise.saleEnd <= 63072000, "7");
         /// set timestamp cap for non-evm Contributor contracts
-        require(raise.unlockTimestamp <= 2**63-1, "7");
+        require(raise.unlockTimestamp <= 2**63-1, "8");
         /// sanity check other raise parameters
-        require(raise.tokenAmount > 0 && raise.tokenAmount <= 2**63-1, "8");
-        require(acceptedTokens.length > 0, "9");
-        require(acceptedTokens.length < 255, "10");
-        require(raise.minRaise > 0, "11");
-        require(raise.maxRaise >= raise.minRaise, "12");
-        require(raise.token != bytes32(0), "13");
-        require(raise.recipient != address(0), "14");
-        require(raise.refundRecipient != address(0), "15");
+        require(raise.tokenAmount > 0, "9");
+        require(acceptedTokens.length > 0, "10");
+        require(acceptedTokens.length < 255, "11");
+        require(raise.minRaise > 0, "12");
+        require(raise.maxRaise >= raise.minRaise, "13");
+        require(raise.token != bytes32(0), "14");
+        require(raise.recipient != address(0), "15");
+        require(raise.refundRecipient != address(0), "16");
         /// confirm that sale authority is set properly
-        require(raise.authority != address(0) && raise.authority != owner(), "16");
+        require(raise.authority != address(0) && raise.authority != owner(), "17");
 
         /// cache wormhole instance 
         IWormhole wormhole = wormhole();
@@ -126,7 +136,7 @@ contract Conductor is ConductorGovernance, ConductorEvents, ReentrancyGuard {
         feeAccounting.valueSent = msg.value;
 
         /// make sure the caller has sent enough eth to cover message fees
-        require(feeAccounting.valueSent >= 2 * feeAccounting.messageFee, "17");
+        require(feeAccounting.valueSent >= 2 * feeAccounting.messageFee, "18");
 
         /// @dev take custody of sale token and fetch decimal/address info for the sale token
         (address localTokenAddress, uint8 localTokenDecimals) = receiveSaleToken(raise);
@@ -177,14 +187,14 @@ contract Conductor is ConductorGovernance, ConductorEvents, ReentrancyGuard {
                 require(
                     sale.acceptedTokensChains[j] != acceptedTokens[i].tokenChain || 
                     sale.acceptedTokensAddresses[j] != acceptedTokens[i].tokenAddress, 
-                    "18"
+                    "19"
                 );
                 unchecked { j += 1; }
             }
 
             /// @dev sanity check accepted tokens
-            require(acceptedTokens[i].conversionRate > 0, "19");
-            require(acceptedTokens[i].tokenAddress != bytes32(0), "20");
+            require(acceptedTokens[i].conversionRate > 0, "20");
+            require(acceptedTokens[i].tokenAddress != bytes32(0), "21");
 
             /// add the unique accepted token information
             sale.acceptedTokensChains[i] = acceptedTokens[i].tokenChain;
@@ -198,7 +208,7 @@ contract Conductor is ConductorGovernance, ConductorEvents, ReentrancyGuard {
                     tokenAddress: acceptedTokens[i].tokenAddress
                 });
                 /// only allow 8 accepted tokens for the Solana Contributor
-                require(_state.solanaAcceptedTokens.length < 8, "21");
+                require(_state.solanaAcceptedTokens.length < 8, "22");
                 /// save in contract storage
                 _state.solanaAcceptedTokens.push(solanaToken);
             }
@@ -300,23 +310,23 @@ contract Conductor is ConductorGovernance, ConductorEvents, ReentrancyGuard {
      * - it refunds the sale tokens to the refundRecipient
      */    
     function abortSaleBeforeStartTime(uint256 saleId) public payable returns (uint256 wormholeSequence) {
-        require(saleExists(saleId), "22");
+        require(saleExists(saleId), "23");
 
         ConductorStructs.Sale memory sale = sales(saleId);
 
         /// confirm that caller is the sale initiator
-        require(sale.initiator == msg.sender, "23");
+        require(sale.initiator == msg.sender, "24");
 
         /// make sure that the sale is still valid and hasn't started yet
-        require(!sale.isSealed && !sale.isAborted, "24");
-        require(block.timestamp < sale.saleStart, "25");
+        require(!sale.isSealed && !sale.isAborted, "25");
+        require(block.timestamp < sale.saleStart, "26");
 
         /// set saleAborted
         setSaleAborted(sale.saleID);   
 
         IWormhole wormhole = wormhole();
         uint256 messageFee = wormhole.messageFee();
-        require(msg.value == messageFee, "26");
+        require(msg.value == messageFee, "27");
 
         /// @dev send encoded SaleAborted struct to Contributor contracts        
         wormholeSequence = wormhole.publishMessage{
@@ -347,27 +357,27 @@ contract Conductor is ConductorGovernance, ConductorEvents, ReentrancyGuard {
         (IWormhole.VM memory vm, bool valid, string memory reason) = wormhole().parseAndVerifyVM(encodedVm);
 
         require(valid, reason);
-        require(verifyContributorVM(vm), "27");
+        require(verifyContributorVM(vm), "28");
 
         /// parse the ContributionsSealed struct emitted by a Contributor contract
         ICCOStructs.ContributionsSealed memory conSealed = ICCOStructs.parseContributionsSealed(vm.payload);
 
-        require(conSealed.chainID == vm.emitterChainId, "28");
+        require(conSealed.chainID == vm.emitterChainId, "29");
 
         /// make sure the sale has ended before accepting contribution information
         ConductorStructs.Sale memory sale = sales(conSealed.saleID);
 
-        require(!sale.isAborted, "29");
-        require(block.timestamp > sale.saleEnd, "30");
+        require(!sale.isAborted, "30");
+        require(block.timestamp > sale.saleEnd, "31");
 
         /// cache because it's referenced several times
         uint256 contributionsLength = conSealed.contributions.length; 
 
         // confirm that contribution information is valid and that it hasn't been collected for this Contributor
-        require(contributionsLength > 0, "31");
+        require(contributionsLength > 0, "32");
         require(!saleContributionIsCollected(
             conSealed.saleID, conSealed.contributions[0].tokenIndex), 
-            "32"
+            "33"
         );
 
         /// @dev set the solanaTokenAccount when consuming a Solana ContributionsSealed
@@ -396,12 +406,12 @@ contract Conductor is ConductorGovernance, ConductorEvents, ReentrancyGuard {
      * - it refunds the refundRecipient if the sale is aborted or the maxRaise is not met (partial refund)
      */
     function sealSale(uint256 saleId) public payable nonReentrant returns (uint256 wormholeSequence, uint256 wormholeSequence2) {
-        require(saleExists(saleId), "33");
+        require(saleExists(saleId), "34");
 
         ConductorStructs.Sale memory sale = sales(saleId);
 
         /// make sure the sale hasn't been aborted or sealed already
-        require(!sale.isSealed && !sale.isAborted, "34");
+        require(!sale.isSealed && !sale.isAborted, "35");
 
         ConductorStructs.SealSaleAccounting memory accounting;       
         ICCOStructs.WormholeFees memory feeAccounting; 
@@ -409,7 +419,7 @@ contract Conductor is ConductorGovernance, ConductorEvents, ReentrancyGuard {
         /// cache accepted tokens length, it will be used in several for loops
         uint256 acceptedTokensLength = sale.acceptedTokensAddresses.length;
         for (uint256 i = 0; i < acceptedTokensLength;) {
-            require(saleContributionIsCollected(saleId, i), "35");
+            require(saleContributionIsCollected(saleId, i), "36");
             /**
             * @dev This calculates the total contribution for each accepted token.
             * - it uses the conversion rate to convert contributions into the minRaise denomination
@@ -430,7 +440,7 @@ contract Conductor is ConductorGovernance, ConductorEvents, ReentrancyGuard {
         feeAccounting.valueSent = msg.value;
 
         /// @dev msg.value must cover all token bridge transfer fees + two saleSealed messages
-        require(feeAccounting.valueSent >= feeAccounting.messageFee * (feeAccounting.bridgeCount + 2), "36");
+        require(feeAccounting.valueSent >= feeAccounting.messageFee * (feeAccounting.bridgeCount + 2), "37");
 
         /// check to see if the sale was successful
         if (accounting.totalContribution >= sale.minRaise) {
@@ -625,8 +635,8 @@ contract Conductor is ConductorGovernance, ConductorEvents, ReentrancyGuard {
         address newAuthority,
         bytes memory sig
     ) public payable onlyOwner returns (uint256 wormholeSequence) {
-        require(saleExists(saleId), "37");
-        require(newAuthority != address(0) && newAuthority != owner(), "38");
+        require(saleExists(saleId), "38");
+        require(newAuthority != address(0) && newAuthority != owner(), "39");
 
         /// @dev verify new authority signature (proves ownership of keys)
         bytes memory encodedHashData = abi.encodePacked(
@@ -634,11 +644,11 @@ contract Conductor is ConductorGovernance, ConductorEvents, ReentrancyGuard {
             address(this),
             saleId
         );
-        require(ICCOStructs.verifySignature(encodedHashData, sig, newAuthority), "39");
+        require(ICCOStructs.verifySignature(encodedHashData, sig, newAuthority), "40");
 
         /// @dev make sure the sale hasn't been sealed/aborted (don't want to rewrite history)
         ConductorStructs.Sale memory sale = sales(saleId);
-        require(!sale.isSealed && !sale.isAborted, "40");
+        require(!sale.isSealed && !sale.isAborted, "41");
 
         /// @dev set new authority for the sale and send VAA
         setNewAuthority(saleId, newAuthority);
@@ -647,7 +657,7 @@ contract Conductor is ConductorGovernance, ConductorEvents, ReentrancyGuard {
         IWormhole wormhole = wormhole();
         uint256 messageFee = wormhole.messageFee();
 
-        require(messageFee == msg.value, "41"); 
+        require(messageFee == msg.value, "42"); 
 
         /// @dev send encoded AuthorityUpdated message to Contributor contracts
         wormholeSequence = wormhole.publishMessage{
@@ -667,16 +677,16 @@ contract Conductor is ConductorGovernance, ConductorEvents, ReentrancyGuard {
      * - it calls abortSale and sends a SaleAborted VAA
     */
     function abortBrickedSale(uint256 saleId) public payable returns (uint256) {
-        require(saleExists(saleId), "42");
+        require(saleExists(saleId), "43");
 
         ConductorStructs.Sale memory sale = sales(saleId);
         /** 
          * Make sure the sale hasn't been aborted or sealed already
          * Make sure the sale ended greater than 7 days ago
         */
-        require(!sale.isSealed && !sale.isAborted, "43");
-        require(block.timestamp > sale.saleEnd + 604800, "44");
-        require(msg.value == wormhole().messageFee(), "45");
+        require(!sale.isSealed && !sale.isAborted, "44");
+        require(block.timestamp > sale.saleEnd + 604800, "45");
+        require(msg.value == wormhole().messageFee(), "46");
 
         return abortSale(saleId, false);
     }

--- a/ethereum/contracts/icco/conductor/Conductor.sol
+++ b/ethereum/contracts/icco/conductor/Conductor.sol
@@ -103,7 +103,7 @@ contract Conductor is ConductorGovernance, ConductorEvents, ReentrancyGuard {
     function createSale(
         ICCOStructs.Raise memory raise,
         ICCOStructs.Token[] memory acceptedTokens   
-    ) public payable nonReentrant returns (
+    ) public payable nonReentrant whenNotPaused returns (
         uint256 saleId,
         uint256 wormholeSequence,
         uint256 wormholeSequence2
@@ -309,7 +309,7 @@ contract Conductor is ConductorGovernance, ConductorEvents, ReentrancyGuard {
      * - it encodes and disseminates a saleAborted message to the Contributor contracts
      * - it refunds the sale tokens to the refundRecipient
      */    
-    function abortSaleBeforeStartTime(uint256 saleId) public payable returns (uint256 wormholeSequence) {
+    function abortSaleBeforeStartTime(uint256 saleId) public payable whenNotPaused returns (uint256 wormholeSequence) {
         require(saleExists(saleId), "23");
 
         ConductorStructs.Sale memory sale = sales(saleId);
@@ -352,7 +352,7 @@ contract Conductor is ConductorGovernance, ConductorEvents, ReentrancyGuard {
      * disseminated by each registered Contributor contract.
      * - it sets the solanaTokenAccount when consuming contributions from the Solana contributor
      */ 
-    function collectContribution(bytes memory encodedVm) public {
+    function collectContribution(bytes memory encodedVm) public whenNotPaused {
         /// validate encodedVm and emitter
         (IWormhole.VM memory vm, bool valid, string memory reason) = wormhole().parseAndVerifyVM(encodedVm);
 
@@ -405,7 +405,7 @@ contract Conductor is ConductorGovernance, ConductorEvents, ReentrancyGuard {
      * - it bridges the sale tokens to the contributor contracts if sealed
      * - it refunds the refundRecipient if the sale is aborted or the maxRaise is not met (partial refund)
      */
-    function sealSale(uint256 saleId) public payable nonReentrant returns (uint256 wormholeSequence, uint256 wormholeSequence2) {
+    function sealSale(uint256 saleId) public payable nonReentrant whenNotPaused returns (uint256 wormholeSequence, uint256 wormholeSequence2) {
         require(saleExists(saleId), "34");
 
         ConductorStructs.Sale memory sale = sales(saleId);
@@ -676,7 +676,7 @@ contract Conductor is ConductorGovernance, ConductorEvents, ReentrancyGuard {
      * - it checks that the sale ended greater than 7 days ago
      * - it calls abortSale and sends a SaleAborted VAA
     */
-    function abortBrickedSale(uint256 saleId) public payable returns (uint256) {
+    function abortBrickedSale(uint256 saleId) public payable whenNotPaused returns (uint256) {
         require(saleExists(saleId), "43");
 
         ConductorStructs.Sale memory sale = sales(saleId);

--- a/ethereum/contracts/icco/conductor/ConductorGovernance.sol
+++ b/ethereum/contracts/icco/conductor/ConductorGovernance.sol
@@ -6,6 +6,7 @@ pragma solidity ^0.8.0;
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "@openzeppelin/contracts/proxy/ERC1967/ERC1967Upgrade.sol";
+import "@openzeppelin/contracts/security/Pausable.sol";
 
 import "../../libraries/external/BytesLib.sol";
 
@@ -15,7 +16,7 @@ import "./ConductorStructs.sol";
 
 import "../../interfaces/IWormhole.sol";
 
-contract ConductorGovernance is ConductorGetters, ConductorSetters, ERC1967Upgrade {
+contract ConductorGovernance is ConductorGetters, ConductorSetters, ERC1967Upgrade, Pausable {
     event ContractUpgraded(address indexed oldContract, address indexed newContract);
     event ConsistencyLevelUpdated(uint8 indexed oldLevel, uint8 indexed newLevel);
     event OwnershipTransfered(address indexed oldOwner, address indexed newOwner);
@@ -26,6 +27,15 @@ contract ConductorGovernance is ConductorGetters, ConductorSetters, ERC1967Upgra
         require(contributorContracts(contributorChainId) == bytes32(0), "2");
         setContributor(contributorChainId, contributorAddress);
     }   
+
+    /// @dev pause conductor operations
+    function pause() public onlyOwner {
+        _pause();
+    }
+    /// @dev unpause conductor operations
+    function unPause() public onlyOwner {
+        _unpause();
+    }
 
     /// @dev upgrade serves to upgrade contract implementations
     function upgrade(uint16 conductorChainId, address newImplementation) public onlyOwner {

--- a/ethereum/contracts/icco/contributor/Contributor.sol
+++ b/ethereum/contracts/icco/contributor/Contributor.sol
@@ -35,7 +35,7 @@ contract Contributor is ContributorGovernance, ContributorEvents, ReentrancyGuar
      * - it validates messages sent via wormhole containing sale information
      * - it saves a copy of the sale in contract storage
      */
-    function initSale(bytes memory saleInitVaa) public {
+    function initSale(bytes memory saleInitVaa) public whenNotPaused {
         /// @dev confirms that the message is from the Conductor and valid
         (IWormhole.VM memory vm, bool valid, string memory reason) = wormhole().parseAndVerifyVM(saleInitVaa);
 
@@ -141,7 +141,7 @@ contract Contributor is ContributorGovernance, ContributorEvents, ReentrancyGuar
      * - it takes custody of contributed funds
      * - it stores information about the contribution and contributor 
      */  
-    function contribute(uint256 saleId, uint256 tokenIndex, uint256 amount, bytes memory sig) public nonReentrant { 
+    function contribute(uint256 saleId, uint256 tokenIndex, uint256 amount, bytes memory sig) public nonReentrant whenNotPaused { 
         require(saleExists(saleId), "sale not initiated");
 
         {/// bypass stack too deep
@@ -216,7 +216,7 @@ contract Contributor is ContributorGovernance, ContributorEvents, ReentrancyGuar
      * - it calculates the total contributions for each accepted token
      * - it disseminates a ContributionSealed struct via wormhole
      */ 
-    function attestContributions(uint256 saleId) public payable returns (uint256 wormholeSequence) {
+    function attestContributions(uint256 saleId) public payable whenNotPaused returns (uint256 wormholeSequence) {
         require(saleExists(saleId), "sale not initiated");
 
         /// confirm that the sale period has ended
@@ -275,7 +275,7 @@ contract Contributor is ContributorGovernance, ContributorEvents, ReentrancyGuar
      * - it determines if all the sale tokens are in custody of this contract
      * - it send the contributed funds to the token sale recipient
      */
-    function saleSealed(bytes memory saleSealedVaa) public payable {
+    function saleSealed(bytes memory saleSealedVaa) public payable whenNotPaused {
         /// @dev confirms that the message is from the Conductor and valid
         (IWormhole.VM memory vm, bool valid, string memory reason) = wormhole().parseAndVerifyVM(saleSealedVaa);
 
@@ -422,7 +422,7 @@ contract Contributor is ContributorGovernance, ContributorEvents, ReentrancyGuar
     }
 
     /// @dev saleAborted serves to mark the sale unnsuccessful or canceled 
-    function saleAborted(bytes memory saleAbortedVaa) public {
+    function saleAborted(bytes memory saleAbortedVaa) public whenNotPaused {
         (IWormhole.VM memory vm, bool valid, string memory reason) = wormhole().parseAndVerifyVM(saleAbortedVaa);
 
         require(valid, reason);
@@ -441,7 +441,7 @@ contract Contributor is ContributorGovernance, ContributorEvents, ReentrancyGuar
      * - it marks the allocation as claimed to prevent multiple claims for the same allocation
      * - it only distributes tokens once the unlock period has ended
      */
-    function claimAllocation(uint256 saleId, uint256 tokenIndex) public {
+    function claimAllocation(uint256 saleId, uint256 tokenIndex) public whenNotPaused {
         require(saleExists(saleId), "sale not initiated");
 
         /// make sure the sale is sealed and not aborted
@@ -499,7 +499,7 @@ contract Contributor is ContributorGovernance, ContributorEvents, ReentrancyGuar
      * - it marks the excessContribution as claimed to prevent multiple claims for the same refund
      * - it transfers the excessContribution to the contributor's wallet
      */
-    function claimExcessContribution(uint256 saleId, uint256 tokenIndex) public {
+    function claimExcessContribution(uint256 saleId, uint256 tokenIndex) public whenNotPaused {
         require(saleExists(saleId), "sale not initiated");
 
         /// return any excess contributions 
@@ -538,7 +538,7 @@ contract Contributor is ContributorGovernance, ContributorEvents, ReentrancyGuar
      * - it confirms that the sale was aborted
      * - it transfers the contributed funds back to the contributor's wallet
      */
-    function claimRefund(uint256 saleId, uint256 tokenIndex) public {
+    function claimRefund(uint256 saleId, uint256 tokenIndex) public whenNotPaused {
         require(saleExists(saleId), "sale not initiated");
 
         (, bool isAborted) = getSaleStatus(saleId);
@@ -568,7 +568,7 @@ contract Contributor is ContributorGovernance, ContributorEvents, ReentrancyGuar
     }
 
     /// @dev saleAuthorityUpdated serves to consume an AuthorityUpdated VAA and change a sale's kyc authority
-    function saleAuthorityUpdated(bytes memory authorityUpdatedVaa) public {
+    function saleAuthorityUpdated(bytes memory authorityUpdatedVaa) public whenNotPaused {
         /// @dev confirms that the message is from the Conductor and valid
         (IWormhole.VM memory vm, bool valid, string memory reason) = wormhole().parseAndVerifyVM(authorityUpdatedVaa);
 

--- a/ethereum/contracts/icco/contributor/ContributorGovernance.sol
+++ b/ethereum/contracts/icco/contributor/ContributorGovernance.sol
@@ -6,6 +6,7 @@ pragma solidity ^0.8.0;
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "@openzeppelin/contracts/proxy/ERC1967/ERC1967Upgrade.sol";
+import "@openzeppelin/contracts/security/Pausable.sol";
 
 import "../../libraries/external/BytesLib.sol";
 
@@ -15,7 +16,7 @@ import "./ContributorStructs.sol";
 
 import "../../interfaces/IWormhole.sol";
 
-contract ContributorGovernance is ContributorGetters, ContributorSetters, ERC1967Upgrade {
+contract ContributorGovernance is ContributorGetters, ContributorSetters, ERC1967Upgrade, Pausable {
     event ContractUpgraded(address indexed oldContract, address indexed newContract);
     event ConsistencyLevelUpdated(uint8 indexed oldLevel, uint8 indexed newLevel);
     event OwnershipTransfered(address indexed oldOwner, address indexed newOwner);
@@ -36,6 +37,16 @@ contract ContributorGovernance is ContributorGetters, ContributorSetters, ERC196
 
         emit ContractUpgraded(currentImplementation, newImplementation);
     } 
+
+    /// @dev pause contributor operations
+    function pause() public onlyOwner {
+        _pause();
+    }
+
+    /// @dev unpause contributor operations
+    function unPause() public onlyOwner {
+        _unpause();
+    }
 
     /// @dev updateConsisencyLevel serves to change the wormhole messaging consistencyLevel
     function updateConsistencyLevel(uint16 contributorChainId, uint8 newConsistencyLevel) public onlyOwner {

--- a/ethereum/contracts/icco/shared/ErrorCodes.sol
+++ b/ethereum/contracts/icco/shared/ErrorCodes.sol
@@ -8,116 +8,118 @@ contract ICCOErrorCodes {
         if (code == 1) {
             errorString = "wrapped address not found on this chain";
         } else if (code == 2) {
+            errorString = "sale token amount too large";
+        } else if (code == 3) {
             errorString = "fee-on-transfer tokens are not supported";
         }
     } 
 
     function createSale(uint256 code) public pure returns (string memory errorString) {
-        if (code == 3) {
+        if (code == 4) {
             errorString = "sale start must be in the future";
-        } else if (code == 4) {
-            errorString = "sale end must be after sale start";
         } else if (code == 5) {
-            errorString = "unlock timestamp should be >= saleEnd";
+            errorString = "sale end must be after sale start";
         } else if (code == 6) {
-            errorString = "unlock timestamp must be <= 2 years in the future";
+            errorString = "unlock timestamp should be >= saleEnd";
         } else if (code == 7) {
-            errorString = "timestamp too large";
+            errorString = "unlock timestamp must be <= 2 years in the future";
         } else if (code == 8) {
-            errorString = "sale token amount must be > 0 and <= 2^63-1";
+            errorString = "timestamp too large";
         } else if (code == 9) {
-            errorString = "must accept at least one token";
+            errorString = "sale token amount must be > 0";
         } else if (code == 10) {
-            errorString = "too many tokens";
+            errorString = "must accept at least one token";
         } else if (code == 11) {
-            errorString = "minRaise must be > 0";
+            errorString = "too many tokens";
         } else if (code == 12) {
-            errorString = "maxRaise must be >= minRaise ";
+            errorString = "minRaise must be > 0";
         } else if (code == 13) {
-            errorString = "token must not be bytes32(0)"; 
+            errorString = "maxRaise must be >= minRaise ";
         } else if (code == 14) {
-            errorString = "recipient must not be address(0)";
+            errorString = "token must not be bytes32(0)"; 
         } else if (code == 15) {
-            errorString = "refundRecipient must not be address(0)";
+            errorString = "recipient must not be address(0)";
         } else if (code == 16) {
-            errorString = "authority must not be address(0) or the owner";
+            errorString = "refundRecipient must not be address(0)";
         } else if (code == 17) {
-            errorString = "insufficient value";
+            errorString = "authority must not be address(0) or the owner";
         } else if (code == 18) {
-            errorString = "duplicate tokens not allowed"; 
+            errorString = "insufficient value";
         } else if (code == 19) {
-            errorString = "conversion rate cannot be zero";
+            errorString = "duplicate tokens not allowed"; 
         } else if (code == 20) {
-            errorString = "acceptedTokens.tokenAddress must not be bytes32(0)";
+            errorString = "conversion rate cannot be zero";
         } else if (code == 21) {
+            errorString = "acceptedTokens.tokenAddress must not be bytes32(0)";
+        } else if (code == 22) {
             errorString = "too many solana tokens";
         } 
     }
         
     function abortSaleBeforeStartTime(uint256 code) public pure returns (string memory errorString) {
-        if (code == 22) {
+        if (code == 23) {
             errorString = "sale not initiated";
-        } else if (code == 23) {
-            errorString = "only initiator can abort the sale early"; 
         } else if (code == 24) {
-            errorString = "already sealed / aborted";
+            errorString = "only initiator can abort the sale early"; 
         } else if (code == 25) {
-            errorString = "sale cannot be aborted once it has started"; 
+            errorString = "already sealed / aborted";
         } else if (code == 26) {
+            errorString = "sale cannot be aborted once it has started"; 
+        } else if (code == 27) {
             errorString = "insufficient value";
         }
     }
 
     function collectContribution(uint256 code) public pure returns (string memory errorString) {
-        if (code == 27) {
+        if (code == 28) {
             errorString = "invalid emitter";
-        } else if (code == 28) {
-            errorString = "contribution from wrong chain id";
         } else if (code == 29) {
-            errorString = "sale was aborted";
+            errorString = "contribution from wrong chain id";
         } else if (code == 30) {
-            errorString = "sale has not ended yet";
+            errorString = "sale was aborted";
         } else if (code == 31) {
-            errorString = "no contributions";
+            errorString = "sale has not ended yet";
         } else if (code == 32) {
+            errorString = "no contributions";
+        } else if (code == 33) {
             errorString = "contribution already collected";
         }
     }
 
     function sealSale(uint256 code) public pure returns (string memory errorString) {     
-         if (code == 33) {
+         if (code == 34) {
             errorString = "sale not initiated";
-        } else if (code == 34) {
-            errorString = "already sealed / aborted";
         } else if (code == 35) {
-            errorString = "missing contribution info";
+            errorString = "already sealed / aborted";
         } else if (code == 36) {
+            errorString = "missing contribution info";
+        } else if (code == 37) {
             errorString = "insufficient value";
         }
     }
        
     function updateSaleAuthority(uint256 code) public pure returns (string memory errorString) {  
-       if (code == 37) {
+       if (code == 38) {
             errorString = "sale not initiated";
-        } else if (code == 38) {
-            errorString = "new authority must not be address(0) or the owner";
         } else if (code == 39) {
-            errorString = "unauthorized authority key";
+            errorString = "new authority must not be address(0) or the owner";
         } else if (code == 40) {
+            errorString = "unauthorized authority key";
+        } else if (code == 41) {
             errorString = "already sealed / aborted ";
         } 
     }  
         
     function abortBrickedSale(uint256 code) public pure returns (string memory errorString) {  
-        if (code == 41) {
+        if (code == 42) {
             errorString = "incorrect value for messageFee";
-        } else if (code == 42) {
-            errorString = "sale not initiated";
         } else if (code == 43) {
-            errorString = "already sealed / aborted";
+            errorString = "sale not initiated";
         } else if (code == 44) {
-            errorString = "sale not old enough";
+            errorString = "already sealed / aborted";
         } else if (code == 45) {
+            errorString = "sale not old enough";
+        } else if (code == 46) {
             errorString = "incorrect value";
         }
     }

--- a/ethereum/test/icco.js
+++ b/ethereum/test/icco.js
@@ -159,7 +159,7 @@ contract("ICCO", function(accounts) {
     assert.ok(failed);
 
     // confirm that the error codes contract returns an error
-    const result = await ERRORS.methods.createSale("9").call();
+    const result = await ERRORS.methods.createSale("10").call();
     assert.equal(result, "must accept at least one token");
 
     const tx = await initialized.methods.registerChain(TEST_CHAIN_ID, contributorAddress).send({
@@ -1338,7 +1338,7 @@ contract("ICCO", function(accounts) {
         gasLimit: GAS_LIMIT,
       });
     } catch (e) {
-      assert.equal(e.message, "Returned error: VM Exception while processing transaction: revert 32");
+      assert.equal(e.message, "Returned error: VM Exception while processing transaction: revert 33");
       failed = true;
     }
 
@@ -1358,7 +1358,7 @@ contract("ICCO", function(accounts) {
         gasLimit: GAS_LIMIT,
       });
     } catch (e) {
-      assert.equal(e.message, "Returned error: VM Exception while processing transaction: revert 33");
+      assert.equal(e.message, "Returned error: VM Exception while processing transaction: revert 34");
       failed = true;
     }
 
@@ -2703,7 +2703,7 @@ contract("ICCO", function(accounts) {
         gasLimit: GAS_LIMIT,
       });
     } catch (e) {
-      assert.equal(e.message, "Returned error: VM Exception while processing transaction: revert 23");
+      assert.equal(e.message, "Returned error: VM Exception while processing transaction: revert 24");
       failed = true;
     }
 
@@ -3911,7 +3911,7 @@ contract("ICCO", function(accounts) {
           gasLimit: GAS_LIMIT,
         });
       } catch (e) {
-        assert.equal(e.message, "Returned error: VM Exception while processing transaction: revert 21");
+        assert.equal(e.message, "Returned error: VM Exception while processing transaction: revert 22");
         failed = true;
       }
       assert.ok(failed);
@@ -3963,7 +3963,7 @@ contract("ICCO", function(accounts) {
           gasLimit: GAS_LIMIT,
         });
       } catch (e) {
-        assert.equal(e.message, "Returned error: VM Exception while processing transaction: revert 17");
+        assert.equal(e.message, "Returned error: VM Exception while processing transaction: revert 18");
         failed = true;
       }
       assert.ok(failed);
@@ -4844,7 +4844,7 @@ contract("ICCO", function(accounts) {
         gasLimit: GAS_LIMIT,
       });
     } catch (e) {
-      assert.equal(e.message, "Returned error: VM Exception while processing transaction: revert 44");
+      assert.equal(e.message, "Returned error: VM Exception while processing transaction: revert 45");
       failed = true;
     }
 
@@ -4975,7 +4975,7 @@ contract("ICCO", function(accounts) {
         gasLimit: GAS_LIMIT,
       });
     } catch (e) {
-      assert.equal(e.message, "Returned error: VM Exception while processing transaction: revert 25");
+      assert.equal(e.message, "Returned error: VM Exception while processing transaction: revert 26");
       failed = true;
     }
 
@@ -5218,7 +5218,7 @@ contract("ICCO", function(accounts) {
         gasLimit: GAS_LIMIT,
       });
     } catch (e) {
-      assert.equal(e.message, "Returned error: VM Exception while processing transaction: revert 19");
+      assert.equal(e.message, "Returned error: VM Exception while processing transaction: revert 20");
       failed = true;
     }
 
@@ -5298,7 +5298,7 @@ contract("ICCO", function(accounts) {
         gasLimit: GAS_LIMIT,
       });
     } catch (e) {
-      assert.equal(e.message, "Returned error: VM Exception while processing transaction: revert 18");
+      assert.equal(e.message, "Returned error: VM Exception while processing transaction: revert 19");
       failed = true;
     }
 
@@ -5367,7 +5367,7 @@ contract("ICCO", function(accounts) {
         gasLimit: GAS_LIMIT,
       });
     } catch (e) {
-      assert.equal(e.message, "Returned error: VM Exception while processing transaction: revert 7");
+      assert.equal(e.message, "Returned error: VM Exception while processing transaction: revert 8");
       failed = true;
     }
 
@@ -5878,7 +5878,7 @@ contract("ICCO", function(accounts) {
         gasLimit: GAS_LIMIT,
       });
     } catch (e) {
-      assert.equal(e.message, "Returned error: VM Exception while processing transaction: revert 14");
+      assert.equal(e.message, "Returned error: VM Exception while processing transaction: revert 15");
       failed = true;
     }
 
@@ -5908,7 +5908,7 @@ contract("ICCO", function(accounts) {
         gasLimit: GAS_LIMIT,
       });
     } catch (e) {
-      assert.equal(e.message, "Returned error: VM Exception while processing transaction: revert 13");
+      assert.equal(e.message, "Returned error: VM Exception while processing transaction: revert 14");
       failed = true;
     }
 
@@ -5938,7 +5938,60 @@ contract("ICCO", function(accounts) {
         gasLimit: GAS_LIMIT,
       });
     } catch (e) {
-      assert.equal(e.message, "Returned error: VM Exception while processing transaction: revert 16");
+      assert.equal(e.message, "Returned error: VM Exception while processing transaction: revert 17");
+      failed = true;
+    }
+
+    assert.ok(failed);
+  });
+
+  it("conductor should cap the sale token amount in Raise parameters", async function() {
+    // test variables
+    const current_block = await web3.eth.getBlock("latest");
+    const saleStart = current_block.timestamp + 5;
+    const saleEnd = saleStart + 8;
+    const saleTokenAmount = "184467440737100000000000000000"; 
+    const minimumTokenRaise = "2000";
+    const maximumTokenRaise = "2000";
+    const tokenOneConversionRate = "1000000000000000000";
+    const recipient = accounts[0]; // make zero address for the test
+    const refundRecipient = accounts[0];
+    const isFixedPriceSale = false;
+
+    // setup smart contracts
+    const initialized = new web3.eth.Contract(ConductorImplementationFullABI, TokenSaleConductor.address);
+
+    // create array (solidity struct) for sale params
+    const saleParams = [
+      isFixedPriceSale,
+      SOLD_TOKEN_BYTES32_ADDRESS,
+      TEST_CHAIN_ID,
+      saleTokenAmount,
+      minimumTokenRaise,
+      maximumTokenRaise,
+      saleStart,
+      saleEnd,
+      saleEnd,
+      recipient,
+      refundRecipient,
+      KYC_AUTHORITY,
+    ];
+
+    // create accepted tokens array
+    const acceptedTokens = [
+      [TEST_CHAIN_ID, "0x000000000000000000000000" + CONTRIBUTED_TOKEN_ONE.address.substr(2), tokenOneConversionRate],
+    ];
+
+    let failed = false;
+    try {
+      // try to create a sale with a sale token amount that is too large
+      await initialized.methods.createSale(saleParams, acceptedTokens).send({
+        value: WORMHOLE_FEE * 2,
+        from: SELLER,
+        gasLimit: GAS_LIMIT,
+      });
+    } catch (e) {
+      assert.equal(e.message, "Returned error: VM Exception while processing transaction: revert 2");
       failed = true;
     }
 
@@ -5993,7 +6046,7 @@ contract("ICCO", function(accounts) {
         gasLimit: GAS_LIMIT,
       });
     } catch (e) {
-      assert.equal(e.message, "Returned error: VM Exception while processing transaction: revert 6");
+      assert.equal(e.message, "Returned error: VM Exception while processing transaction: revert 7");
       failed = true;
     }
 


### PR DESCRIPTION
- Import OpenZeplin Pausable in Conductor Governance and Contributor Governance.
- Implement pause and unpause owner functions in Governance contracts.
- Implement **whenNotPause** modifier in Conductor and Contributor contracts with all public functions.
- Add Test cases in icco.js file to test create Sale fail on Conductor contract and contribution fail on Contribution contract  if pause is enable by admin on any of them.